### PR TITLE
deploy to Rinkeby

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -20,6 +20,11 @@ module.exports = {
             network_id: 3,
             gasPrice: 10000000000
         },
+        rinkeby: {
+            provider: () => new PrivateKeyProvider(process.env.PK, 'https://rinkeby.infura.io'),
+            network_id: 4,
+            gasPrice: 10000000000
+        },
         coverage: {
             host: 'localhost',
             network_id: '*',


### PR DESCRIPTION
- added Rinkeby config to `truffle.js`
- deployed contracts to Rinkeby:
  - Hydro Token [0xD586FEfC58865884d1ba69646C9ED587ce9dD0E6](https://rinkeby.etherscan.io/address/0xd586fefc58865884d1ba69646c9ed587ce9dd0e6)  
  - Proxy [0x67A4e271949Cd9A5b704904fC316eF507d8C7bEB](https://rinkeby.etherscan.io/address/0x67a4e271949cd9a5b704904fc316ef507d8c7beb)     
  - HybridExchange [0x5842e020ce9928F878777c1e3B62A790e425Fcc4](https://rinkeby.etherscan.io/address/0x5842e020ce9928F878777c1e3B62A790e425Fcc4) 
  - Test DAI [0x20318bbD21aD4b0c26c0BD4F3e376DD12B703D16](https://rinkeby.etherscan.io/address/0x20318bbd21ad4b0c26c0bd4f3e376dd12b703d16)
- Published verified code for `Proxy` and `HydroToken` on Etherscan but couldn't do it for `HybridExchange` - tried with `truffle-flattener` and as multiple files. I guess it's failing because of `pragma experimental`, didn't play too much with it as you can publish the verified code too.
- Owner address is `0x9aaf197F25d207ecE17DfBeb20780095f7623A23`. 
Happy to transfer ownership of deployed contracts to your address if you need it to make this deployment the "official" Rinkeby deployment

See also: https://github.com/HydroProtocol/hydro-scaffold-dex/pull/33