### PR TITLE
Feature/funding bugfix 0.2

### DIFF
--- a/contracts/components/OperationsComponent.sol
+++ b/contracts/components/OperationsComponent.sol
@@ -46,6 +46,7 @@ library OperationsComponent {
         Requires.requireDecimalLessOrEquanThanOne(market.auctionRatioPerBlock);
         Requires.requireDecimalGreaterThanOne(market.liquidateRate);
         Requires.requireDecimalGreaterThanOne(market.withdrawRate);
+        Requires.requireWithdrawRateGreaterThanLiquidateRate(market.withdrawRate, market.liquidateRate);
 
         state.markets[state.marketsCount++] = market;
         Events.logCreateMarket(market);
@@ -66,6 +67,7 @@ library OperationsComponent {
         Requires.requireDecimalLessOrEquanThanOne(newAuctionRatioPerBlock);
         Requires.requireDecimalGreaterThanOne(newLiquidateRate);
         Requires.requireDecimalGreaterThanOne(newWithdrawRate);
+        Requires.requireWithdrawRateGreaterThanLiquidateRate(newWithdrawRate, newLiquidateRate);
 
         state.markets[marketID].auctionRatioStart = newAuctionRatioStart;
         state.markets[marketID].auctionRatioPerBlock = newAuctionRatioPerBlock;

--- a/contracts/components/OperationsComponent.sol
+++ b/contracts/components/OperationsComponent.sol
@@ -46,7 +46,7 @@ library OperationsComponent {
         Requires.requireDecimalLessOrEquanThanOne(market.auctionRatioPerBlock);
         Requires.requireDecimalGreaterThanOne(market.liquidateRate);
         Requires.requireDecimalGreaterThanOne(market.withdrawRate);
-        Requires.requireWithdrawRateGreaterThanLiquidateRate(market.withdrawRate, market.liquidateRate);
+        require(market.withdrawRate > market.liquidateRate, "WITHDARW_RATE_LESS_OR_EQUAL_THAN_LIQUIDATE_RATE");
 
         state.markets[state.marketsCount++] = market;
         Events.logCreateMarket(market);
@@ -67,7 +67,7 @@ library OperationsComponent {
         Requires.requireDecimalLessOrEquanThanOne(newAuctionRatioPerBlock);
         Requires.requireDecimalGreaterThanOne(newLiquidateRate);
         Requires.requireDecimalGreaterThanOne(newWithdrawRate);
-        Requires.requireWithdrawRateGreaterThanLiquidateRate(newWithdrawRate, newLiquidateRate);
+        require(newWithdrawRate > newLiquidateRate, "WITHDARW_RATE_LESS_OR_EQUAL_THAN_LIQUIDATE_RATE");
 
         state.markets[marketID].auctionRatioStart = newAuctionRatioStart;
         state.markets[marketID].auctionRatioPerBlock = newAuctionRatioPerBlock;

--- a/contracts/funding/BatchActions.sol
+++ b/contracts/funding/BatchActions.sol
@@ -215,7 +215,7 @@ library BatchActions {
 
         Requires.requireMarketIDExist(state, marketID);
         Requires.requireMarketIDAndAssetMatch(state, marketID, asset);
-        Requiers.requireAccountNormal(state, marketID, msg.sender);
+        Requires.requireAccountNormal(state, marketID, msg.sender);
         LendingPool.borrow(
             state,
             msg.sender,

--- a/contracts/funding/BatchActions.sol
+++ b/contracts/funding/BatchActions.sol
@@ -215,6 +215,7 @@ library BatchActions {
 
         Requires.requireMarketIDExist(state, marketID);
         Requires.requireMarketIDAndAssetMatch(state, marketID, asset);
+        Requiers.requireAccountNormal(state, marketID, msg.sender);
         LendingPool.borrow(
             state,
             msg.sender,

--- a/contracts/lib/Requires.sol
+++ b/contracts/lib/Requires.sol
@@ -137,7 +137,7 @@ library Requires {
         internal
         pure
     {
-        require(market.withdrawRate > market.liquidateRate, "WITHDARW_RATE_LESS_OR_EQUAL_THAN_LIQUIDATE_RATE");
+        require(withdrawRate > liquidateRate, "WITHDARW_RATE_LESS_OR_EQUAL_THAN_LIQUIDATE_RATE");
     }
 
     function requireMarketIDExist(

--- a/contracts/lib/Requires.sol
+++ b/contracts/lib/Requires.sol
@@ -130,16 +130,6 @@ library Requires {
         require(decimal > Decimal.one(), "DECIMAL_LESS_OR_EQUAL_THAN_ONE");
     }
 
-    function requireWithdrawRateGreaterThanLiquidateRate(
-        uint256 withdrawRate,
-        uint256 liquidateRate
-    )
-        internal
-        pure
-    {
-        require(withdrawRate > liquidateRate, "WITHDARW_RATE_LESS_OR_EQUAL_THAN_LIQUIDATE_RATE");
-    }
-
     function requireMarketIDExist(
         Store.State storage state,
         uint16 marketID

--- a/contracts/lib/Requires.sol
+++ b/contracts/lib/Requires.sol
@@ -130,6 +130,16 @@ library Requires {
         require(decimal > Decimal.one(), "DECIMAL_LESS_OR_EQUAL_THAN_ONE");
     }
 
+    function requireWithdrawRateGreaterThanLiquidateRate(
+        uint256 withdrawRate,
+        uint256 liquidateRate
+    )
+        internal
+        pure
+    {
+        require(market.withdrawRate > market.liquidateRate, "WITHDARW_RATE_LESS_OR_EQUAL_THAN_LIQUIDATE_RATE");
+    }
+
     function requireMarketIDExist(
         Store.State storage state,
         uint16 marketID

--- a/contracts/lib/Requires.sol
+++ b/contracts/lib/Requires.sol
@@ -148,11 +148,22 @@ library Requires {
         view
     {
         if (path.category == Types.BalanceCategory.CollateralAccount) {
-            require(
-                state.accounts[path.user][path.marketID].status == Types.CollateralAccountStatus.Normal,
-                "CAN_NOT_OPERATOR_LIQUIDATING_COLLATERAL_ACCOUNT"
-            );
+            requireAccountNormal(state, path.marketID, path.user);
         }
+    }
+
+    function requireAccountNormal(
+        Store.State storage state,
+        uint16 marketID,
+        address user
+    )
+        internal
+        view
+    {
+        require(
+            state.accounts[user][marketID].status == Types.CollateralAccountStatus.Normal,
+            "CAN_NOT_OPERATE_LIQUIDATING_COLLATERAL_ACCOUNT"
+        );
     }
 
     function requirePathMarketIDAssetMatch(

--- a/test/funding/liquidate_test.js
+++ b/test/funding/liquidate_test.js
@@ -272,7 +272,7 @@ contract('Liquidate', accounts => {
         // can't transfer funds in
         await assert.rejects(
             depositMarket(marketID, usdAsset, u2, toWei('100')),
-            /CAN_NOT_OPERATOR_LIQUIDATING_COLLATERAL_ACCOUNT/
+            /CAN_NOT_OPERATE_LIQUIDATING_COLLATERAL_ACCOUNT/
         );
 
         // can't transfer funds out

--- a/test/funding/liquidate_test.js
+++ b/test/funding/liquidate_test.js
@@ -294,7 +294,7 @@ contract('Liquidate', accounts => {
                     from: u2
                 }
             ),
-            /CAN_NOT_OPERATOR_LIQUIDATING_COLLATERAL_ACCOUNT/
+            /CAN_NOT_OPERATE_LIQUIDATING_COLLATERAL_ACCOUNT/
         );
     });
 


### PR DESCRIPTION
Bug fix according to PeckShield Report V0.2

 - [critical] liquidating account borrow
 - [low] require withdraw rate greater than liquidate rate