### PR TITLE
Feature/new interest model

### DIFF
--- a/contracts/funding/GentleInterestModel.sol
+++ b/contracts/funding/GentleInterestModel.sol
@@ -1,0 +1,40 @@
+/*
+
+    Copyright 2019 The Hydro Protocol Foundation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity ^0.5.8;
+pragma experimental ABIEncoderV2;
+
+contract GentleInterestModel {
+    uint256 constant BASE = 10**18;
+
+    /**
+     * @param borrowRatio a decimal with 18 decimals
+     */
+    function polynomialInterestModel(uint256 borrowRatio) external pure returns(uint256) {
+        // 0.1r + 0.2r^16 + 0.2*r^32
+
+        // the valid range of borrowRatio is [0, 1]
+        uint256 r = borrowRatio > BASE ? BASE : borrowRatio;
+        uint256 r16 = r*r/BASE; // r^2
+        r16 = r16*r16/BASE; // r^4
+        r16 = r16*r16/BASE; // r^8
+        r16 = r16*r16/BASE; // r^16
+    
+        return r / 10 + r16 / 5 + r16 * r16 / BASE / 5;
+    }
+}

--- a/contracts/helper/Eth2daiDirect.sol
+++ b/contracts/helper/Eth2daiDirect.sol
@@ -1,0 +1,56 @@
+/**
+ *Submitted for verification at Etherscan.io on 2018-03-16
+*/
+
+pragma solidity ^0.5.8;
+
+contract Eth2daiInterface {
+    // sellAllAmount(ERC20 pay_gem, uint pay_amt, ERC20 buy_gem, uint min_fill_amount)
+    function sellAllAmount(address, uint, address, uint) public returns (uint);
+}
+
+contract TokenInterface {
+    function balanceOf(address) public returns (uint);
+    function allowance(address, address) public returns (uint);
+    function approve(address, uint) public;
+    function transfer(address,uint) public returns (bool);
+    function transferFrom(address, address, uint) public returns (bool);
+    function deposit() public payable;
+    function withdraw(uint) public;
+}
+
+contract Eth2daiDirect {
+
+    Eth2daiInterface public constant eth2dai = Eth2daiInterface(0x39755357759cE0d7f32dC8dC45414CCa409AE24e);
+    TokenInterface public constant wethToken = TokenInterface(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    TokenInterface public constant daiToken = TokenInterface(0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359);
+
+    function marketBuyEth(
+        uint256 payDaiAmount,
+        uint256 minBuyEthAmount
+    )
+        public
+    {
+        daiToken.transferFrom(msg.sender, address(this), payDaiAmount);
+        uint256 fillAmount = eth2dai.sellAllAmount(address(daiToken), payDaiAmount, address(wethToken), minBuyEthAmount);
+        wethToken.withdraw(fillAmount);
+        msg.sender.transfer(fillAmount);
+    }
+
+    function marketSellEth(
+        uint256 payEthAmount,
+        uint256 minBuyDaiAmount
+    )
+        public
+        payable
+    {
+        require(msg.value == payEthAmount, "MSG_VALUE_NOT_MATCH");
+        wethToken.deposit.value(msg.value)();
+        uint256 fillAmount = eth2dai.sellAllAmount(address(wethToken), payEthAmount, address(daiToken), minBuyDaiAmount);
+        daiToken.transfer(msg.sender, fillAmount);
+    }
+
+    function() external payable {
+        require(msg.sender == address(wethToken), "CONTRACT_NOT_PAYABLE");
+    }
+}


### PR DESCRIPTION
# Background

Since we updated interest model the market changed a lot. DDEX's interest rate is obviously higher than other protocols and it's time to adjust the interest model.

# Other protocol's interest rate model

[Compound](https://compound.finance/markets/USDT) and [AAVE](https://docs.aave.com/risk/liquidity-risk/borrow-interest-rate#usdc-or-dai-or-usdt) (click to see their curve) use jump interest rate model, which jump up at a certain interest rate.

DYDX use the formula Y=(0.1 * X) + (0.1 * X^32) + (0.3 * X^64).

We could find two key features:
 - End up at about 50%
 - Be sharp when utilization rate is greater than ~90%

# Our new interest rate

Y = 0.1x + 0.2x^16 + 0.2*x^32

As you can see, basically, our curve follows dydx's curve but becomes sharp earlier than dydx's. That's because our pool size is relatively small and should reserve more space for users' withdraw.

After the adjustment, interest rate on DDEX becomes flatter and more friendly for traders.

![image](https://user-images.githubusercontent.com/16594532/87813220-13bba100-c894-11ea-849b-fefb08ff26c5.png)

